### PR TITLE
feat(FE): implement question bank frontend

### DIFF
--- a/frontend/src/pages/admin/api.js
+++ b/frontend/src/pages/admin/api.js
@@ -349,6 +349,9 @@ export default {
   },
   getGroupList () {
     return ajax('admin/group/', 'get')
+  },
+  getProblemLevelCount () {
+    return ajax('admin/problem_level_count/')
   }
 }
 

--- a/frontend/src/pages/admin/api.js
+++ b/frontend/src/pages/admin/api.js
@@ -352,6 +352,14 @@ export default {
   },
   getProblemLevelCount () {
     return ajax('admin/problem_level_count/')
+  },
+  getProblemBankContestProblem (contestID, problemID) {
+    return ajax('bank/problem/', 'get', {
+      params: {
+        problem_id: problemID,
+        contest_id: contestID
+      }
+    })
   }
 }
 

--- a/frontend/src/pages/admin/views/contest/Contest.vue
+++ b/frontend/src/pages/admin/views/contest/Contest.vue
@@ -317,14 +317,14 @@
                 </b-col>
                 <b-col cols="3">
                   <div class="d-flex">
-                    <p class="bank-filter__count">X</p>
+                    <span class="bank-filter__count">X</span>
                     <b-form-input
                       v-model="range.count"
                       placeholder="the number of this problems"
                       type="number"
                       style="max-width:60px"
                     />
-                    <p class="bank-filter__count">/ {{ problemLevelCount[range.level] || 0 }}</p>
+                    <span class="bank-filter__count">/ {{ problemLevelCount[range.level] || 0 }}</span>
                   </div>
                 </b-col>
                 <b-col cols="1">
@@ -399,7 +399,7 @@ export default {
       endTime: '',
       endDate: '',
       levelOptions: [
-        { value: null, text: 'Select Please', disabled: true },
+        { value: 'unselected', text: 'Select Please', disabled: true },
         'Level1',
         'Level2',
         'Level3',
@@ -409,7 +409,7 @@ export default {
         'Level7'
       ],
       problemTagList: [
-        { value: null, text: 'Select Please', disabled: true }
+        { value: 'unselected', text: 'Select Please', disabled: true }
         // TODO: Problem Tag List should be made
       ],
       problemLevelCount: {

--- a/frontend/src/pages/admin/views/contest/Contest.vue
+++ b/frontend/src/pages/admin/views/contest/Contest.vue
@@ -298,42 +298,41 @@
               </p>
             </template>
             <div>
-              <div
+              <b-row
                 v-for="(range, index) in contest.bank_filter"
-                :key="index"
+                :key="range.id"
+                style="margin-bottom: 15px"
               >
-                <b-row style="margin-bottom: 15px">
-                  <b-col cols="3">
-                    <b-form-select
-                      v-model="range.level"
-                      :options="levelOptions"
+                <b-col cols="3">
+                  <b-form-select
+                    v-model="range.level"
+                    :options="levelOptions"
+                  />
+                </b-col>
+                <b-col cols="3">
+                  <b-form-select
+                    v-model="range.tag"
+                    :options="problemTagList"
+                  />
+                </b-col>
+                <b-col cols="3">
+                  <div class="d-flex">
+                    <p class="bank-filter__count">X</p>
+                    <b-form-input
+                      v-model="range.count"
+                      placeholder="the number of this problems"
+                      type="number"
+                      style="max-width:60px"
                     />
-                  </b-col>
-                  <b-col cols="3">
-                    <b-form-select
-                      v-model="range.tag"
-                      :options="problemTagList"
-                    />
-                  </b-col>
-                  <b-col cols="3">
-                    <div class="d-flex">
-                      <p style="font-size: 20px; margin-right:5px; padding: 0.275rem 0.1rem">X</p>
-                      <b-form-input
-                        v-model="range.count"
-                        placeholder="the number of this problems"
-                        type="number"
-                        style="max-width:60px"
-                      />
-                      <p style="font-size: 20px; margin-left:5px; padding: 0.275rem 0.1rem">/ {{ problemLevelCount[range.level] || 0 }}</p>
-                    </div>
-                  </b-col>
-                  <b-col cols="1">
-                    <b-button @click="removeBankFilter(range)" variant="outline-secondary">
-                        <b-icon icon="trash-fill"></b-icon>
-                    </b-button>
-                  </b-col>
-                </b-row>
-              </div>
+                    <p class="bank-filter__count">/ {{ problemLevelCount[range.level] || 0 }}</p>
+                  </div>
+                </b-col>
+                <b-col cols="1">
+                  <b-button @click="removeBankFilter(index)" variant="outline-secondary">
+                      <b-icon icon="trash-fill"></b-icon>
+                  </b-button>
+                </b-col>
+              </b-row>
               <b-col cols="1">
                 <b-button @click="addBankFilter" variant="outline-secondary">
                     <b-icon icon="plus"></b-icon>
@@ -386,7 +385,6 @@ export default {
         allowed_ip_ranges: [{
           value: ''
         }],
-        is_bank_filter: false,
         bank_filter: [
           // {
           //   level: "unselected",
@@ -410,7 +408,10 @@ export default {
         'Level6',
         'Level7'
       ],
-      problemTagList: [],
+      problemTagList: [
+        { value: null, text: 'Select Please', disabled: true },
+        // TODO: Problem Tag List should be made
+      ],
       problemLevelCount: {
         // "null": 0,
         // "Level1": 1,
@@ -580,20 +581,18 @@ export default {
       }
     },
     async getProblemLevelCount () {
-      const response = await api.getProblemLevelCount()
-      const data = response.data.data
+      const data = await api.getProblemLevelCount().then((x) => x.data.data)
       data.unselected = 0
       this.problemLevelCount = data
     },
     addBankFilter () {
       this.contest.bank_filter.push({
-        level: null,
+        level: 'unselected',
         tag: '',
         count: 0
       })
     },
-    removeBankFilter (range) {
-      const index = this.contest.bank_filter.indexOf(range)
+    removeBankFilter (index) {
       if (index !== -1) {
         this.contest.bank_filter.splice(index, 1)
       }
@@ -605,5 +604,10 @@ export default {
 <style scoped>
   .row, .col {
     word-wrap: break-word;
+  }
+  .bank-filter__count {
+    font-size: 20px;
+    margin-right:5px;
+    padding: 0.275rem 0.1rem;
   }
 </style>

--- a/frontend/src/pages/admin/views/contest/Contest.vue
+++ b/frontend/src/pages/admin/views/contest/Contest.vue
@@ -409,7 +409,7 @@ export default {
         'Level7'
       ],
       problemTagList: [
-        { value: null, text: 'Select Please', disabled: true },
+        { value: null, text: 'Select Please', disabled: true }
         // TODO: Problem Tag List should be made
       ],
       problemLevelCount: {

--- a/frontend/src/pages/admin/views/contest/Contest.vue
+++ b/frontend/src/pages/admin/views/contest/Contest.vue
@@ -315,13 +315,17 @@
                       :options="problemTagList"
                     />
                   </b-col>
-                  <p style="font-size: 25px">X</p>
-                  <b-col cols="2">
-                    <b-form-input
-                      v-model="range.count"
-                      placeholder="the number of this problems"
-                      type="number"
-                    />
+                  <b-col cols="3">
+                    <div class="d-flex">
+                      <p style="font-size: 20px; margin-right:5px; padding: 0.275rem 0.1rem">X</p>
+                      <b-form-input
+                        v-model="range.count"
+                        placeholder="the number of this problems"
+                        type="number"
+                        style="max-width:60px"
+                      />
+                      <p style="font-size: 20px; margin-left:5px; padding: 0.275rem 0.1rem">/ {{ problemLevelCount[range.level] || 0 }}</p>
+                    </div>
                   </b-col>
                   <b-col cols="1">
                     <b-button @click="removeBankFilter(range)" variant="outline-secondary">
@@ -385,7 +389,7 @@ export default {
         is_bank_filter: false,
         bank_filter: [
           // {
-          //   level: null,
+          //   level: "unselected",
           //   tag: '',
           //   count: 0
           // }
@@ -406,7 +410,13 @@ export default {
         'Level6',
         'Level7'
       ],
-      problemTagList: []
+      problemTagList: [],
+      problemLevelCount: {
+        // "null": 0,
+        // "Level1": 1,
+        // "Level2": 3,
+        // "Level5": 2,
+      }
     }
   },
   async mounted () {
@@ -470,6 +480,7 @@ export default {
       }
     }
     await this.getProblemTagList()
+    await this.getProblemLevelCount()
   },
   methods: {
     async saveContest () {
@@ -567,6 +578,12 @@ export default {
       for (const tag of response.data.data) {
         this.problemTagList.push(tag.name)
       }
+    },
+    async getProblemLevelCount () {
+      const response = await api.getProblemLevelCount()
+      const data = response.data.data
+      data.unselected = 0
+      this.problemLevelCount = data
     },
     addBankFilter () {
       this.contest.bank_filter.push({

--- a/frontend/src/pages/admin/views/contest/Contest.vue
+++ b/frontend/src/pages/admin/views/contest/Contest.vue
@@ -290,6 +290,54 @@
             </div>
           </b-form-group>
         </b-col>
+        <b-col cols="12">
+          <b-form-group>
+            <template #label>
+              <p class="labels" style="margin-top:16px">
+                Problem Bank
+              </p>
+            </template>
+            <div>
+              <div
+                v-for="(range, index) in contest.bank_filter"
+                :key="index"
+              >
+                <b-row style="margin-bottom: 15px">
+                  <b-col cols="3">
+                    <b-form-select
+                      v-model="range.level"
+                      :options="levelOptions"
+                    />
+                  </b-col>
+                  <b-col cols="3">
+                    <b-form-select
+                      v-model="range.tag"
+                      :options="problemTagList"
+                    />
+                  </b-col>
+                  <p style="font-size: 25px">X</p>
+                  <b-col cols="2">
+                    <b-form-input
+                      v-model="range.count"
+                      placeholder="the number of this problems"
+                      type="number"
+                    />
+                  </b-col>
+                  <b-col cols="1">
+                    <b-button @click="removeBankFilter(range)" variant="outline-secondary">
+                        <b-icon icon="trash-fill"></b-icon>
+                    </b-button>
+                  </b-col>
+                </b-row>
+              </div>
+              <b-col cols="1">
+                <b-button @click="addBankFilter" variant="outline-secondary">
+                    <b-icon icon="plus"></b-icon>
+                </b-button>
+              </b-col>
+            </div>
+          </b-form-group>
+        </b-col>
       </b-row>
       <save @click.native="saveContest" />
     </Panel>
@@ -333,13 +381,32 @@ export default {
         visible: true,
         allowed_ip_ranges: [{
           value: ''
-        }]
+        }],
+        is_bank_filter: false,
+        bank_filter: [
+          // {
+          //   level: null,
+          //   tag: '',
+          //   count: 0
+          // }
+        ]
       },
       groupOptions: [],
       startTime: '',
       startDate: '',
       endTime: '',
-      endDate: ''
+      endDate: '',
+      levelOptions: [
+        { value: null, text: 'Select Please', disabled: true },
+        'Level1',
+        'Level2',
+        'Level3',
+        'Level4',
+        'Level5',
+        'Level6',
+        'Level7'
+      ],
+      problemTagList: []
     }
   },
   async mounted () {
@@ -402,6 +469,7 @@ export default {
       } catch (err) {
       }
     }
+    await this.getProblemTagList()
   },
   methods: {
     async saveContest () {
@@ -492,6 +560,25 @@ export default {
       const index = this.contest.prizes.indexOf(range)
       if (index !== -1 && this.contest.prizes.length !== 1) {
         this.contest.prizes.splice(index, 1)
+      }
+    },
+    async getProblemTagList () {
+      const response = await api.getProblemTagList()
+      for (const tag of response.data.data) {
+        this.problemTagList.push(tag.name)
+      }
+    },
+    addBankFilter () {
+      this.contest.bank_filter.push({
+        level: null,
+        tag: '',
+        count: 0
+      })
+    },
+    removeBankFilter (range) {
+      const index = this.contest.bank_filter.indexOf(range)
+      if (index !== -1) {
+        this.contest.bank_filter.splice(index, 1)
       }
     }
   }

--- a/frontend/src/pages/admin/views/general/Announcement.vue
+++ b/frontend/src/pages/admin/views/general/Announcement.vue
@@ -316,9 +316,9 @@ export default {
         ? await this.getProblemBankContestProblem()
         : await this.getContestProblemList()
       this.problemOption = data.map(item => ({
-          value: item.id,
-          text: item._id + ' ' + item.title
-        })
+        value: item.id,
+        text: item._id + ' ' + item.title
+      })
       )
     },
     async getProblemBankContestProblem () {

--- a/frontend/src/pages/admin/views/general/Announcement.vue
+++ b/frontend/src/pages/admin/views/general/Announcement.vue
@@ -206,7 +206,8 @@ export default {
       },
       announcementDialogTitle: 'Edit Announcement',
       currentPage: 0,
-      problemOption: []
+      problemOption: [],
+      bank: false
     }
   },
   watch: {
@@ -220,6 +221,10 @@ export default {
   methods: {
     async init () {
       this.contestID = this.$route.params.contestId
+      const res = await api.getContest(this.contestID)
+      if (res.data.data.is_bank === true) {
+        this.bank = true
+      }
       if (this.contestID) {
         await this.getContestAnnouncementList()
       } else {
@@ -307,17 +312,27 @@ export default {
       }
     },
     async getProblemOption () {
-      const res = await api.getContestProblemList({
-        contest_id: this.contestID,
-        limit: 100,
-        offset: 0
-      })
-      this.problemOption = res.data.data.results.map(item => {
+      const data = this.bank
+        ? await this.getProblemBankContestProblem()
+        : await this.getContestProblemList()
+      this.problemOption = data.map(item => {
         return {
           value: item.id,
           text: item._id + ' ' + item.title
         }
       })
+    },
+    async getProblemBankContestProblem () {
+      const res = await api.getProblemBankContestProblem(this.contestID)
+      return res.data.data
+    },
+    async getContestProblemList () {
+      const res = await api.getContestProblemList({
+        contest_id: this.contestID,
+        limit: 100,
+        offset: 0
+      })
+      return res.data.data.results
     },
     async openAnnouncementDialog (id) {
       this.showEditAnnouncementDialog = true

--- a/frontend/src/pages/admin/views/general/Announcement.vue
+++ b/frontend/src/pages/admin/views/general/Announcement.vue
@@ -315,12 +315,11 @@ export default {
       const data = this.bank
         ? await this.getProblemBankContestProblem()
         : await this.getContestProblemList()
-      this.problemOption = data.map(item => {
-        return {
+      this.problemOption = data.map(item => ({
           value: item.id,
           text: item._id + ' ' + item.title
-        }
-      })
+        })
+      )
     },
     async getProblemBankContestProblem () {
       const res = await api.getProblemBankContestProblem(this.contestID)

--- a/frontend/src/pages/admin/views/problem/Problem.vue
+++ b/frontend/src/pages/admin/views/problem/Problem.vue
@@ -124,26 +124,6 @@
       </b-row>
 
       <b-row>
-        <b-col cols="2">
-          <p class="labels">
-            Visible
-          </p>
-          <b-form-checkbox
-            v-model="problem.visible"
-            switch
-          >
-          </b-form-checkbox>
-        </b-col>
-        <b-col cols="2">
-          <p class="labels">
-            Share Submission
-          </p>
-          <b-form-checkbox
-            v-model="problem.share_submission"
-            switch
-          >
-          </b-form-checkbox>
-        </b-col>
         <b-col cols="4">
           <p class="labels">
             <span class="text-danger">*</span> Tag
@@ -194,7 +174,39 @@
             </b-form-tags>
           </div>
         </b-col>
+        <b-col cols="2">
+          <p class="labels">
+            Visible
+          </p>
+          <b-form-checkbox
+            v-model="problem.visible"
+            switch
+          >
+          </b-form-checkbox>
+        </b-col>
+        <b-col cols="2">
+          <p class="labels">
+            Share Submission
+          </p>
+          <b-form-checkbox
+            v-model="problem.share_submission"
+            switch
+          >
+          </b-form-checkbox>
+        </b-col>
         <b-col cols="4">
+          <p class="labels">
+            Include in problem bank pool
+          </p>
+          <b-form-checkbox
+            v-model="problem.bank"
+            switch
+          >
+          </b-form-checkbox>
+        </b-col>
+      </b-row>
+      <b-row>
+        <b-col cols="12">
           <b-form-group>
             <template v-slot:label>
               <p class="labels">
@@ -219,7 +231,6 @@
           </b-form-group>
         </b-col>
       </b-row>
-
       <div>
         <b-form-group v-for="(sample, index) in problem.samples" :key="'sample'+index">
           <Accordion :title="'Sample' + (index + 1)">
@@ -497,6 +508,7 @@ export default {
       textsizeOver50mb: true,
       allLanguage: {},
       inputVisible: false,
+      bank: false,
       tagInput: '',
       problemTagList: [],
       template: {},
@@ -548,6 +560,7 @@ export default {
       difficulty: 'Level1',
       visible: true,
       share_submission: false,
+      bank: false,
       tags: [],
       languages: [],
       template: {},

--- a/frontend/src/pages/admin/views/problem/ProblemList.vue
+++ b/frontend/src/pages/admin/views/problem/ProblemList.vue
@@ -25,6 +25,9 @@
             @keyup.enter.native="handleInlineEdit(row.item)"
           />
         </template>
+        <template #cell(is_bank)="row">
+          <span v-show="row.item.bank">🏦</span>
+        </template>
         <template #cell(edit-title)="row">
           <span v-show="!row.item.isEditing">{{ row.item.title }}</span>
           <b-form-input
@@ -152,6 +155,7 @@ export default {
       fields: [
         { key: 'id', label: 'ID', tdClass: 'problemListTable' },
         { key: 'edit-id', label: 'Display ID', tdClass: 'problemListTable' },
+        { key: 'is_bank', label: 'Bank', tdClass: 'problemListTable' },
         { key: 'edit-title', label: 'Title', tdClass: 'problemListTable' },
         { key: 'created_by.username', label: 'Author', tdClass: 'problemListTable' },
         { key: 'create-time', label: 'Create Time', tdClass: 'problemListTable' },

--- a/frontend/src/pages/oj/api.js
+++ b/frontend/src/pages/oj/api.js
@@ -318,6 +318,21 @@ export default {
   getGroupList () {
     return ajax('group/', 'get', {
     })
+  },
+  startProblemBankContest (contestID) {
+    return ajax('contest/bank/', 'post', {
+      data: {
+        contest_id: contestID
+      }
+    })
+  },
+  getProblemBankContestProblem (contestID, problemID) {
+    return ajax('bank/problem/', 'get', {
+      params: {
+        problem_id: problemID,
+        contest_id: contestID
+      }
+    })
   }
 }
 

--- a/frontend/src/pages/oj/api.js
+++ b/frontend/src/pages/oj/api.js
@@ -333,6 +333,13 @@ export default {
         contest_id: contestID
       }
     })
+  },
+  getProblemBankParticipation (contestID) {
+    return ajax('contest/bank/', 'get', {
+      params: {
+        contest_id: contestID
+      }
+    })
   }
 }
 

--- a/frontend/src/pages/oj/views/contest/ContestProblemList.vue
+++ b/frontend/src/pages/oj/views/contest/ContestProblemList.vue
@@ -101,7 +101,7 @@ export default {
           return
         }
         this.contestProblems = await this.$store.dispatch(
-          this.contest.is_bank ? 'getProblemBankContestProblems': 'getContestProblems'
+          this.contest.is_bank ? 'getProblemBankContestProblems' : 'getContestProblems'
         ).then((x) => x.data.data)
         this.total = this.contestProblems.length
       } catch (err) {

--- a/frontend/src/pages/oj/views/contest/ContestProblemList.vue
+++ b/frontend/src/pages/oj/views/contest/ContestProblemList.vue
@@ -100,15 +100,9 @@ export default {
           // not participating now
           return
         }
-
-        var res2
-        if (!this.contest.is_bank) {
-          res2 = await this.$store.dispatch('getContestProblems')
-        } else {
-          res2 = await this.$store.dispatch('getProblemBankContestProblems')
-        }
-        const data = res2.data.data
-        this.contestProblems = data
+        this.contestProblems = await this.$store.dispatch(
+          this.contest.is_bank ? 'getProblemBankContestProblems': 'getContestProblems'
+        ).then((x) => x.data.data)
         this.total = this.contestProblems.length
       } catch (err) {
       }

--- a/frontend/src/pages/oj/views/contest/ContestProblemList.vue
+++ b/frontend/src/pages/oj/views/contest/ContestProblemList.vue
@@ -99,7 +99,7 @@ export default {
         if (!this.contest.is_bank) {
           res = await this.$store.dispatch('getContestProblems')
         } else {
-          res = await api.getProblemBankContestProblem(this.contest.id)
+          res = await this.$store.dispatch('getProblemBankContestProblems')
         }
         const data = res.data.data
         this.contestProblems = data

--- a/frontend/src/pages/oj/views/contest/ContestProblemList.vue
+++ b/frontend/src/pages/oj/views/contest/ContestProblemList.vue
@@ -95,13 +95,19 @@ export default {
   methods: {
     async getContestProblems () {
       try {
-        var res
-        if (!this.contest.is_bank) {
-          res = await this.$store.dispatch('getContestProblems')
-        } else {
-          res = await this.$store.dispatch('getProblemBankContestProblems')
+        const res = await api.getProblemBankParticipation(this.contestID)
+        if (!res.data.data) {
+          // not participating now
+          return
         }
-        const data = res.data.data
+
+        var res2
+        if (!this.contest.is_bank) {
+          res2 = await this.$store.dispatch('getContestProblems')
+        } else {
+          res2 = await this.$store.dispatch('getProblemBankContestProblems')
+        }
+        const data = res2.data.data
         this.contestProblems = data
         this.total = this.contestProblems.length
       } catch (err) {

--- a/frontend/src/pages/oj/views/problem/Problem.vue
+++ b/frontend/src/pages/oj/views/problem/Problem.vue
@@ -505,12 +505,7 @@ export default {
       }
     },
     async getContestProblems () {
-      let res
-      if (!this.bank) {
-        res = await this.$store.dispatch('getContestProblems')
-      } else {
-        res = await this.$store.dispatch('getProblemBankContestProblems')
-      }
+      const res = await this.$store.dispatch(this.bank ? 'getProblemBankContestProblems': 'getContestProblems')
       if (this.isAuthenticated) {
         if (
           this.contestRuleType === 'ACM' ||

--- a/frontend/src/pages/oj/views/problem/Problem.vue
+++ b/frontend/src/pages/oj/views/problem/Problem.vue
@@ -505,7 +505,7 @@ export default {
       }
     },
     async getContestProblems () {
-      const res = await this.$store.dispatch(this.bank ? 'getProblemBankContestProblems': 'getContestProblems')
+      const res = await this.$store.dispatch(this.bank ? 'getProblemBankContestProblems' : 'getContestProblems')
       if (this.isAuthenticated) {
         if (
           this.contestRuleType === 'ACM' ||

--- a/frontend/src/pages/oj/views/problem/Problem.vue
+++ b/frontend/src/pages/oj/views/problem/Problem.vue
@@ -23,7 +23,7 @@
             <b-icon icon="chevron-right" />
           </b-nav-item>
           <b-nav-item :to="'/contest/' + this.contestID">{{
-            problem.contest_name || contest.title /* problem bank일 경우 contest_name이 없음 */
+            problem.contest_name || this.contest_title /* problem bank일 경우 contest_name이 없음 */
           }}</b-nav-item>
           <b-nav-item>
             <b-icon icon="chevron-right" />
@@ -438,6 +438,7 @@ export default {
       if (route === 'contest-problem-details') {
         const res2 = await api.getContest(this.contestID)
         this.bank = res2.data.data.is_bank
+        this.contest_title = res2.data.data.title
         if (!this.bank) {
           res = await api.getContestProblem(this.problemID, this.contestID)
         } else {

--- a/frontend/src/pages/oj/views/problem/Problem.vue
+++ b/frontend/src/pages/oj/views/problem/Problem.vue
@@ -23,7 +23,7 @@
             <b-icon icon="chevron-right" />
           </b-nav-item>
           <b-nav-item :to="'/contest/' + this.contestID">{{
-            problem.contest_name
+            problem.contest_name || contest.title /* problem bank일 경우 contest_name이 없음 */
           }}</b-nav-item>
           <b-nav-item>
             <b-icon icon="chevron-right" />
@@ -303,6 +303,8 @@
             :hide="hide"
             :contestID="contestID"
             :problemID="problemID"
+            :bank="bank"
+            v-if="renderSidebar"
           />
         </template>
       </b-sidebar>
@@ -351,6 +353,8 @@ export default {
       contestID: '',
       problemID: '',
       courseID: '',
+      bank: false,
+      renderSidebar: false,
       assignmentID: '',
       assignment_name: '',
       submitting: false,
@@ -432,7 +436,13 @@ export default {
       var res
 
       if (route === 'contest-problem-details') {
-        res = await api.getContestProblem(this.problemID, this.contestID)
+        const res2 = await api.getContest(this.contestID)
+        this.bank = res2.data.data.is_bank
+        if (!this.bank) {
+          res = await api.getContestProblem(this.problemID, this.contestID)
+        } else {
+          res = await api.getProblemBankContestProblem(this.contestID, this.problemID)
+        }
       } else if (route === 'lecture-assignment-problem-details') {
         res = await api.getCourseAssignmentProblem(
           this.assignmentID,
@@ -441,6 +451,7 @@ export default {
       } else {
         res = await api.getProblem(this.problemID)
       }
+      this.renderSidebar = true
 
       const problem = res.data.data
       this.changeDomTitle({ title: problem.title })
@@ -493,7 +504,12 @@ export default {
       }
     },
     async getContestProblems () {
-      const res = await this.$store.dispatch('getContestProblems')
+      let res
+      if (!this.bank) {
+        res = await this.$store.dispatch('getContestProblems')
+      } else {
+        res = await this.$store.dispatch('getProblemBankContestProblems')
+      }
       if (this.isAuthenticated) {
         if (
           this.contestRuleType === 'ACM' ||
@@ -604,6 +620,9 @@ export default {
         code: this.code,
         contest_id: this.contestID,
         assignment_id: this.assignmentID
+      }
+      if (this.bank) {
+        delete data.contest_id
       }
       if (this.captchaRequired) {
         data.captcha = this.captchaCode

--- a/frontend/src/pages/oj/views/problem/ProblemSidebar.vue
+++ b/frontend/src/pages/oj/views/problem/ProblemSidebar.vue
@@ -320,12 +320,7 @@ export default {
   },
   methods: {
     async getContestProblems () {
-      let res
-      if (!this.bank) {
-        res = await this.$store.dispatch('getContestProblems')
-      } else {
-        res = await this.$store.dispatch('getProblemBankContestProblems')
-      }
+      const res = await this.$store.dispatch(this.bank ? 'getProblemBankContestProblems': 'getContestProblems')
       if (this.isAuthenticated) {
         if (this.contestRuleType === 'ACM') {
           this.addStatusColumn(this.ACMTableColumns, res.data.data)

--- a/frontend/src/pages/oj/views/problem/ProblemSidebar.vue
+++ b/frontend/src/pages/oj/views/problem/ProblemSidebar.vue
@@ -320,7 +320,7 @@ export default {
   },
   methods: {
     async getContestProblems () {
-      const res = await this.$store.dispatch(this.bank ? 'getProblemBankContestProblems': 'getContestProblems')
+      const res = await this.$store.dispatch(this.bank ? 'getProblemBankContestProblems' : 'getContestProblems')
       if (this.isAuthenticated) {
         if (this.contestRuleType === 'ACM') {
           this.addStatusColumn(this.ACMTableColumns, res.data.data)

--- a/frontend/src/pages/oj/views/problem/ProblemSidebar.vue
+++ b/frontend/src/pages/oj/views/problem/ProblemSidebar.vue
@@ -243,7 +243,12 @@ export default {
     CodeMirror,
     Table
   },
-  props: ['hide', 'contestID', 'problemID'],
+  props: {
+    hide: Boolean,
+    contestID: Number,
+    problemID: Number,
+    bank: Boolean
+  },
   data () {
     return {
       assignmentID: '',
@@ -307,7 +312,7 @@ export default {
       this.assignmentID = this.$route.params.assignmentID
       await this.getCourseAssignmentProblemList()
     }
-    if (this.$route.params.contestID || this.$route.params.assignmentID) {
+    if ((this.$route.params.contestID && !this.bank) || this.$route.params.assignmentID) {
       this.submission_table_fields.unshift({ key: 'Problem' })
       this.submission_info_table_fields.unshift({ label: 'Problem', key: 'problem' })
     }
@@ -315,7 +320,12 @@ export default {
   },
   methods: {
     async getContestProblems () {
-      const res = await this.$store.dispatch('getContestProblems')
+      let res
+      if (!this.bank) {
+        res = await this.$store.dispatch('getContestProblems')
+      } else {
+        res = await this.$store.dispatch('getProblemBankContestProblems')
+      }
       if (this.isAuthenticated) {
         if (this.contestRuleType === 'ACM') {
           this.addStatusColumn(this.ACMTableColumns, res.data.data)
@@ -381,11 +391,12 @@ export default {
       params.problem_id = this.problemID
       params.assignment_id = this.assignmentID
       var func
-      if (this.contestID) {
+      if (this.contestID && !this.bank) {
         func = 'getContestSubmissionList'
       } else if (this.assignmentID) {
         func = 'getAssignmentSubmissionList'
       } else {
+        delete params.contest_id // Problem Bank specified action
         func = 'getSubmissionList'
       }
 

--- a/frontend/src/store/modules/contest.js
+++ b/frontend/src/store/modules/contest.js
@@ -21,7 +21,6 @@ const state = {
 }
 
 const getters = {
-  // contest 是否加载完成
   contestLoaded: (state) => {
     return !!state.contest.status
   },
@@ -155,6 +154,26 @@ const actions = {
   async getContestProblems ({ commit, rootState }) {
     try {
       const res = await api.getContestProblemList(rootState.route.params.contestID)
+      res.data.data.sort((a, b) => {
+        const aId = isNaN(a._id) ? a._id : a._id * 1
+        const bId = isNaN(b._id) ? b._id : b._id * 1
+        if (aId === bId) {
+          return 0
+        } else if (aId > bId) {
+          return 1
+        }
+        return -1
+      })
+      commit(types.CHANGE_CONTEST_PROBLEMS, { contestProblems: res.data.data })
+      return res
+    } catch (err) {
+      commit(types.CHANGE_CONTEST_PROBLEMS, { contestProblems: [] })
+      throw err
+    }
+  },
+  async getProblemBankContestProblems ({ commit, rootState }) {
+    try {
+      const res = await api.getProblemBankContestProblem(rootState.route.params.contestID)
       res.data.data.sort((a, b) => {
         const aId = isNaN(a._id) ? a._id : a._id * 1
         const bId = isNaN(b._id) ? b._id : b._id * 1


### PR DESCRIPTION
문제은행 프론트엔드를 구현합니다.

### Admin Contest
![image](https://user-images.githubusercontent.com/73051219/158061551-b45d269e-e3b2-481d-950f-ccb5c4a75629.png)
문제은행 필터에 해당하는 필드가 추가되어 있습니다.
레벨과 태그으로 조건을 지정하고 해당 조건의 문제 수를 입력할 수 있습니다.

### Admin Announcement
#269에서 Contest Announcement(=Clarification)를 만들 때 related problem을 지정할 수 있도록 하였기 때문에, 문제은행 사용시에도 사용할 수 있도록 하기 위하여 사용하는 api를 diverge 했습니다.


### Admin Problem
General Problem을 문제은행 풀에 포함할 지 여부를 확인하는 체크박스를 추가하였습니다. 필드 하나가 추가됨에 따라 순서를 바꿔 보기 좋게 변경하였습니다. 

### oj ContestProblemList
문제은행 대회를 시작하는 버튼을 추가했습니다. 버튼을 누르면 ProblemBankAPI Post를 부릅니다. (ProblemBank API Post: 해당 유저에게 문제들을 랜덤으로 배치하여 풀 수 있게 합니다. API PR 참고)

### oj Problem
문제은행 대회의 경우에도 사이드바, 코드 제출 등이 작동되도록 수정했습니다. 기존에는 사이드바를 Problem.vue와 같이 렌더링하였지만 코드 구조 상 불가피하여 조금 있다가 렌더링해주도록 변경했습니다. (문제은행의 경우에도 route는 기존 contest와 똑같이 사용하므로 문제은행인지 알려면 contest 정보(getContest) 를 불러와야 하는데 기존 코드 구조대로라면 사이드바와 Problem 두 곳에서 모두 불러야만 했으므로 이 때문에 변경한 것. 문제은행 문제를 Contest에 포함시킨 게 아니라 기존 problem 모델에서 같이 사용하는 것의 어쩔 수 없는 문제였음. 나중에 코드 리팩토링하면서 구조를 바꿔야할 것)

### oj ProblemSidebar
oj problem 참고해주세요.

close #350 