### PR TITLE
fix(fe): problem info stacking up / post card broken (#353, #354)

### DIFF
--- a/frontend/src/pages/oj/views/general/Home.vue
+++ b/frontend/src/pages/oj/views/general/Home.vue
@@ -27,7 +27,7 @@
             <div class="w-80">{{data.row.title}}</div>
           </template>
           <template v-slot:create_time="data">
-            {{ getTimeFormat(data.row.create_time, 'MMM D, YYYY') }}
+            <span class="whitespace-nowrap">{{ getTimeFormat(data.row.create_time, 'MMM D, YYYY') }}</span>
           </template>
         </Table>
       </b-card>
@@ -56,7 +56,7 @@
             <div class="w-80">{{ data.row.title }}</div>
           </template>
           <template v-slot:start_time="data" class="text-right">
-            {{ getTimeFormat(data.row.start_time, "MMM D, YYYY") }}
+            <span class="whitespace-nowrap">{{ getTimeFormat(data.row.start_time, "MMM D, YYYY") }}</span>
           </template>
         </Table>
       </b-card>
@@ -222,6 +222,7 @@ export default {
     margin-bottom: 30px;
     height: 255px;
     width: 45%;
+    min-width: 600px;
     &-table {
       cursor: pointer;
       :hover {
@@ -250,7 +251,7 @@ export default {
     }
   }
 
-  @media screen and (max-width: 1016px) {
+  @media screen and (max-width: 1300px) {
     .post-card {
       width:80%;
       margin-top: 40px;

--- a/frontend/src/pages/oj/views/problem/Problem.vue
+++ b/frontend/src/pages/oj/views/problem/Problem.vue
@@ -453,6 +453,7 @@ export default {
       const problemInfo = {}
       this.$set(problemInfo, 'time_limit', problem.time_limit + ' ms')
       this.$set(problemInfo, 'memory_limit', problem.memory_limit + ' MB')
+      this.problemInfo.pop()
       this.problemInfo.push(problemInfo)
 
       let precode = storage.get(buildProblemCodeKey(this.problemID, this.contestID))


### PR DESCRIPTION
close #353 : 대회 문제들 간에 이동할 때 같은 컴포넌트 간에 이동이기 때문에 push를 통하여 계속 problemInfo가 쌓이는 이슈가 있었음. push해주기 전에 기존 정보를 pop하여 쌓이지 않게 함.

close #354 : 특정 화면 비율에서 post card가 깨지는 것을 방지함. 
![image](https://user-images.githubusercontent.com/73051219/158110924-31e93521-61ee-4c66-b9bb-e054225e80a2.png)
